### PR TITLE
chore: remove local settings from repo

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(cargo test:*)",
-      "Bash(tokei:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Thumbs.db
 # Environment
 .env
 .env.local
+
+# Claude Code local settings
+.claude/settings.local.json


### PR DESCRIPTION
Removes accidentally committed `.claude/settings.local.json` and adds it to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)