### PR TITLE
fix: use Trusted Publishing for crates.io releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,15 @@ jobs:
         env:
           RUSTDOCFLAGS: "-D warnings"
 
-  # Publish crates to crates.io
+  # Publish crates to crates.io using Trusted Publishing
   publish:
     name: Publish
     needs: ci
     runs-on: ubuntu-latest
+    environment: crates-io
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -57,7 +61,7 @@ jobs:
 
       # Publish core first (models depends on it)
       - name: Publish azure_ai_foundry_core
-        run: cargo publish -p azure_ai_foundry_core --token ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish -p azure_ai_foundry_core
 
       # Wait for crates.io to index the new crate
       - name: Wait for crates.io indexing
@@ -65,7 +69,7 @@ jobs:
 
       # Publish models (depends on core)
       - name: Publish azure_ai_foundry_models
-        run: cargo publish -p azure_ai_foundry_models --token ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish -p azure_ai_foundry_models
 
   # Create GitHub Release
   github-release:


### PR DESCRIPTION
## Summary

Fix release workflow to use Trusted Publishing instead of API token.

### Changes
- Remove `--token` argument from `cargo publish`
- Add `id-token: write` permission for OIDC authentication
- Add `environment: crates-io` for protection rules

### Why
The crate was configured in crates.io to require Trusted Publishing, causing the v0.2.0 release to fail with:
```
status 403 Forbidden: New versions of this crate can only be published using Trusted Publishing
```

### Note
After merging, you'll need to:
1. Create a GitHub Environment called `crates-io` (Settings → Environments)
2. Re-run the release workflow or create a new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)