### PR TITLE
fix: add OIDC token exchange for Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,15 @@ jobs:
           fi
           echo "Version verified: $TAG_VERSION"
 
+      # Get OIDC token and exchange for crates.io publish token
+      - name: Get crates.io token via Trusted Publishing
+        id: crates-token
+        run: |
+          OIDC_TOKEN=$(curl -sLS "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=crates.io" -H "User-Agent: actions/oidc-client" -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" | jq -r '.value')
+          CRATES_TOKEN=$(curl -sLS "https://crates.io/api/v1/tokens/oidc" -H "Authorization: Bearer $OIDC_TOKEN" | jq -r '.token')
+          echo "::add-mask::$CRATES_TOKEN"
+          echo "CARGO_REGISTRY_TOKEN=$CRATES_TOKEN" >> $GITHUB_ENV
+
       # Publish core first (models depends on it)
       - name: Publish azure_ai_foundry_core
         run: cargo publish -p azure_ai_foundry_core


### PR DESCRIPTION
## Summary

Complete the Trusted Publishing setup by adding OIDC token exchange.

### Changes
1. Get OIDC token from GitHub Actions (`ACTIONS_ID_TOKEN_REQUEST_URL`)
2. Exchange with crates.io API (`/api/v1/tokens/oidc`)
3. Set `CARGO_REGISTRY_TOKEN` for cargo publish

### Why
The previous fix added permissions but didn't actually exchange the OIDC token for a crates.io publish token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)