### PR TITLE
fix: correct crates.io Trusted Publishing API endpoint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,21 @@ jobs:
       - name: Get crates.io token via Trusted Publishing
         id: crates-token
         run: |
+          set -e
           OIDC_TOKEN=$(curl -sLS "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=crates.io" -H "User-Agent: actions/oidc-client" -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" | jq -r '.value')
-          CRATES_TOKEN=$(curl -sLS "https://crates.io/api/v1/tokens/oidc" -H "Authorization: Bearer $OIDC_TOKEN" | jq -r '.token')
+          echo "Got OIDC token (length: ${#OIDC_TOKEN})"
+          RESPONSE=$(curl -sLS -X POST "https://crates.io/api/v1/trusted_publishing/tokens" \
+            -H "Content-Type: application/json" \
+            -d "{\"jwt\": \"$OIDC_TOKEN\"}")
+          echo "Response: $RESPONSE" | head -c 100
+          CRATES_TOKEN=$(echo "$RESPONSE" | jq -r '.token')
+          if [ "$CRATES_TOKEN" == "null" ] || [ -z "$CRATES_TOKEN" ]; then
+            echo "Failed to get crates.io token. Response: $RESPONSE"
+            exit 1
+          fi
           echo "::add-mask::$CRATES_TOKEN"
           echo "CARGO_REGISTRY_TOKEN=$CRATES_TOKEN" >> $GITHUB_ENV
+          echo "Successfully obtained crates.io token"
 
       # Publish core first (models depends on it)
       - name: Publish azure_ai_foundry_core


### PR DESCRIPTION
## Summary

Fix the crates.io Trusted Publishing API endpoint and request format.

### Changes
- Use `POST /api/v1/trusted_publishing/tokens` (not `/api/v1/tokens/oidc`)
- Send JWT in request body as JSON: `{"jwt": "..."}`
- Add error handling and debug output

### Why
The previous endpoint was wrong, causing 401 Unauthorized errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)