### PR TITLE
fix: use official crates-io-auth-action for Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,29 +59,16 @@ jobs:
           fi
           echo "Version verified: $TAG_VERSION"
 
-      # Get OIDC token and exchange for crates.io publish token
-      - name: Get crates.io token via Trusted Publishing
-        id: crates-token
-        run: |
-          set -e
-          OIDC_TOKEN=$(curl -sLS "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=crates.io" -H "User-Agent: actions/oidc-client" -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" | jq -r '.value')
-          echo "Got OIDC token (length: ${#OIDC_TOKEN})"
-          RESPONSE=$(curl -sLS -X POST "https://crates.io/api/v1/trusted_publishing/tokens" \
-            -H "Content-Type: application/json" \
-            -d "{\"jwt\": \"$OIDC_TOKEN\"}")
-          echo "Response: $RESPONSE" | head -c 100
-          CRATES_TOKEN=$(echo "$RESPONSE" | jq -r '.token')
-          if [ "$CRATES_TOKEN" == "null" ] || [ -z "$CRATES_TOKEN" ]; then
-            echo "Failed to get crates.io token. Response: $RESPONSE"
-            exit 1
-          fi
-          echo "::add-mask::$CRATES_TOKEN"
-          echo "CARGO_REGISTRY_TOKEN=$CRATES_TOKEN" >> $GITHUB_ENV
-          echo "Successfully obtained crates.io token"
+      # Get crates.io token via Trusted Publishing (official action)
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: crates-auth
 
       # Publish core first (models depends on it)
       - name: Publish azure_ai_foundry_core
         run: cargo publish -p azure_ai_foundry_core
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
 
       # Wait for crates.io to index the new crate
       - name: Wait for crates.io indexing
@@ -90,6 +77,8 @@ jobs:
       # Publish models (depends on core)
       - name: Publish azure_ai_foundry_models
         run: cargo publish -p azure_ai_foundry_models
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
 
   # Create GitHub Release
   github-release:


### PR DESCRIPTION
## Summary
- Replace manual OIDC token exchange with `rust-lang/crates-io-auth-action@v1`
- Automatic token revocation on workflow completion
- Cleaner code: 8 lines added, 19 removed

## Test plan
- [ ] Merge PR to main
- [ ] Publish crates manually first (required for Trusted Publishing)
- [ ] Configure Trusted Publisher in crates.io UI for each crate
- [ ] Create tag `v0.2.0` to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)