### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-02-21
+
+### Added
+
+#### New Crate: `azure_ai_foundry_agents`
+- `agent` module: create, get, list, delete agents
+- `thread` module: create, get, delete conversation threads
+- `message` module: create, list, get messages in threads
+- `run` module: create, get, create_thread_and_run, poll_until_complete
+
+#### Tracing Instrumentation
+- Full `tracing` spans across all API calls (chat, embeddings, agents)
+- Span fields for model, token usage, agent_id, thread_id, run_id, etc.
+
+#### Core Improvements
+- `FoundryClient::delete()` method for DELETE requests
+- `FoundryClient` fields made private (encapsulation)
+- Input validation in builders (empty strings, parameter ranges)
+
+### Security
+- **HTTPS Required**: Endpoint URLs must use HTTPS (except localhost for development)
+- **Token Refresh Buffer**: Increased from 60s to 120s to prevent race conditions in slow networks
+- **SSE Parsing**: Defensive checks for empty/malformed lines
+
+### Changed
+- `get_token()` deprecated → use `fetch_fresh_token()`
+- `EmbeddingUsage` removed → use `Usage` from core
+- `AzureSdk` error variant changed from `(String)` to `{ message, source }`
+
+### Breaking Changes
+- `FoundryClient::builder().endpoint("http://...")` now fails with `InvalidEndpoint` error
+- HTTP is only allowed for localhost/127.0.0.1 for local development
+
 ## [0.2.0] - 2025-02-15
 
 ### Added
@@ -70,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API keys wrapped with `secrecy` crate to prevent accidental logging
 - Error message truncation to prevent sensitive data leakage
 
-[Unreleased]: https://github.com/bzsanti/azure-ai-foundry/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/bzsanti/azure-ai-foundry/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/bzsanti/azure-ai-foundry/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/bzsanti/azure-ai-foundry/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/bzsanti/azure-ai-foundry/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/sdk/azure_ai_foundry_agents/Cargo.toml
+++ b/sdk/azure_ai_foundry_agents/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-azure_ai_foundry_core = { path = "../azure_ai_foundry_core", version = "0.2.0" }
+azure_ai_foundry_core = { path = "../azure_ai_foundry_core", version = "0.3.0" }
 serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true

--- a/sdk/azure_ai_foundry_models/Cargo.toml
+++ b/sdk/azure_ai_foundry_models/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-azure_ai_foundry_core = { path = "../azure_ai_foundry_core", version = "0.2.0" }
+azure_ai_foundry_core = { path = "../azure_ai_foundry_core", version = "0.3.0" }
 serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true


### PR DESCRIPTION
## Summary

Version bump for v0.3.0 release.

### Changes

- Update workspace version from 0.2.0 to 0.3.0
- Update dependency versions in models and agents crates  
- Add CHANGELOG entry for v0.3.0

### After merge

Create and push tag:
```bash
git tag -a v0.3.0 -m "Release v0.3.0"
git push origin v0.3.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)