### PR TITLE
fix(ci): check specific version before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,44 +81,69 @@ jobs:
         uses: rust-lang/crates-io-auth-action@v1
         id: crates-auth
 
-      # Check which crates exist on crates.io (for first-time publish detection)
-      - name: Check crate existence
+      # Get version from Cargo.toml
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      # Check which crates/versions are already published
+      - name: Check crate versions
         id: check-crates
         run: |
-          check_crate() {
-            if curl -s "https://crates.io/api/v1/crates/$1" | grep -q '"crate":'; then
-              echo "exists"
+          VERSION="${{ steps.version.outputs.version }}"
+
+          check_crate_version() {
+            CRATE=$1
+            # Check if crate exists
+            RESPONSE=$(curl -s "https://crates.io/api/v1/crates/$CRATE")
+            if ! echo "$RESPONSE" | grep -q '"crate":'; then
+              echo "new"  # Crate doesn't exist at all
+              return
+            fi
+            # Check if specific version exists
+            if echo "$RESPONSE" | grep -q "\"num\":\"$VERSION\""; then
+              echo "published"  # This version already published
             else
-              echo "new"
+              echo "exists"  # Crate exists but not this version
             fi
           }
-          echo "core=$(check_crate azure_ai_foundry_core)" >> $GITHUB_OUTPUT
-          echo "models=$(check_crate azure_ai_foundry_models)" >> $GITHUB_OUTPUT
-          echo "agents=$(check_crate azure_ai_foundry_agents)" >> $GITHUB_OUTPUT
+
+          echo "core=$(check_crate_version azure_ai_foundry_core)" >> $GITHUB_OUTPUT
+          echo "models=$(check_crate_version azure_ai_foundry_models)" >> $GITHUB_OUTPUT
+          echo "agents=$(check_crate_version azure_ai_foundry_agents)" >> $GITHUB_OUTPUT
+
+          echo "Status: core=${{ steps.check-crates.outputs.core }}, models=${{ steps.check-crates.outputs.models }}, agents=${{ steps.check-crates.outputs.agents }}"
 
       # Publish core first (models and agents depend on it)
       - name: Publish azure_ai_foundry_core
+        if: steps.check-crates.outputs.core != 'published'
         run: cargo publish -p azure_ai_foundry_core
         env:
-          # Use manual token for first publish, trusted publishing for subsequent
+          # Use manual token for first publish (new), trusted publishing for existing crate
           CARGO_REGISTRY_TOKEN: ${{ steps.check-crates.outputs.core == 'new' && secrets.CRATES_IO_TOKEN || steps.crates-auth.outputs.token }}
 
       # Wait for crates.io to index the new crate
       - name: Wait for crates.io indexing
+        if: steps.check-crates.outputs.core != 'published'
         run: sleep 30
 
       # Publish models (depends on core)
       - name: Publish azure_ai_foundry_models
+        if: steps.check-crates.outputs.models != 'published'
         run: cargo publish -p azure_ai_foundry_models
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.check-crates.outputs.models == 'new' && secrets.CRATES_IO_TOKEN || steps.crates-auth.outputs.token }}
 
       # Wait for crates.io to index
       - name: Wait for crates.io indexing
+        if: steps.check-crates.outputs.models != 'published'
         run: sleep 30
 
       # Publish agents (depends on core)
       - name: Publish azure_ai_foundry_agents
+        if: steps.check-crates.outputs.agents != 'published'
         run: cargo publish -p azure_ai_foundry_agents
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.check-crates.outputs.agents == 'new' && secrets.CRATES_IO_TOKEN || steps.crates-auth.outputs.token }}


### PR DESCRIPTION
## Summary

Fixes the release workflow to properly check if a specific version is already published.

### Problem

The previous check only verified if the crate exists, not if the specific version was already published. This caused failures when re-running the workflow.

### Solution

- Check if exact `crate@version` is already on crates.io
- Skip publish step if version already published
- States: `new` (first publish), `exists` (new version), `published` (skip)

### After merge

Run workflow manually with `v0.3.0` - it will skip core/models and only publish agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)