### PR TITLE
fix: add User-Agent header to crates.io API requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,23 +89,35 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       # Check which crates/versions are already published using HTTP status codes
+      # Note: crates.io API requires User-Agent header
       - name: Check crate versions
         id: check-crates
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           echo "Checking version: $VERSION"
 
+          # crates.io requires User-Agent header
+          UA="azure-ai-foundry-release-workflow/1.0 (github-actions)"
+
           check_crate_status() {
             local CRATE=$1
-            # Check if specific version exists (returns 200 if published)
             local HTTP_CODE
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/$CRATE/$VERSION")
+
+            # Check if specific version exists (returns 200 if published)
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "User-Agent: $UA" \
+              "https://crates.io/api/v1/crates/$CRATE/$VERSION")
+            echo "DEBUG: $CRATE version check returned HTTP $HTTP_CODE" >&2
+
             if [ "$HTTP_CODE" = "200" ]; then
               echo "published"
               return
             fi
+
             # Check if crate exists at all
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/$CRATE")
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "User-Agent: $UA" \
+              "https://crates.io/api/v1/crates/$CRATE")
+            echo "DEBUG: $CRATE existence check returned HTTP $HTTP_CODE" >&2
+
             if [ "$HTTP_CODE" = "200" ]; then
               echo "exists"
             else


### PR DESCRIPTION
## Summary
- Added required `User-Agent` header to all crates.io API requests
- crates.io API blocks requests without User-Agent, causing all version checks to fail
- Added DEBUG output to help diagnose future issues

## Root Cause
The previous runs showed `Core: new`, `Models: new`, `Agents: new` even though these crates exist because crates.io was rejecting the requests without User-Agent.

## Test Plan
- [ ] Merge this PR
- [ ] Run release workflow with tag `v0.3.0`
- [ ] Verify DEBUG output shows HTTP 200 for core/models version checks
- [ ] Verify only agents gets published

🤖 Generated with [Claude Code](https://claude.com/claude-code)